### PR TITLE
Docs: Mejorar el mensaje de creación de bandera en .bashrc durante la instalación

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -113,7 +113,8 @@ if [ ! -f "$ENTORNO_UNO_LOCK_FILE" ]; then
         if bash "$setup_script_path"; then
             touch "$ENTORNO_UNO_LOCK_FILE"
             echo "Instalación completada y bandera creada en '$ENTORNO_UNO_LOCK_FILE'."
-            echo "Esta bandera es temporal y se eliminará al reciclar la VM, disparando una nueva instalación."
+            echo "Nota: La bandera es temporal. En Cloud Shell, se borra al reciclar la VM, permitiendo la auto-reparación."
+            echo "En sistemas persistentes, para forzar una reparación manual, ejecute de nuevo 'setup_dev_tools.sh'."
         else
             echo "ADVERTENCIA: El script de instalación falló. La bandera no se creará." >&2
         fi


### PR DESCRIPTION
**Descripción:**

 Este Pull Request añade más claridad al proceso de instalación, modificando el mensaje final que se muestra en la terminal para que el usuario entienda mejor el comportamiento del script en diferentes sistemas.
    
 **El Cambio:**
    
 *   Se ha actualizado el `echo` en el archivo `.bashrc` para explicar brevemente la naturaleza temporal de la bandera de instalación.
 *   El nuevo mensaje informa al usuario sobre la auto-reparación en Cloud Shell y cómo proceder en sistemas persistentes.
    
 Este cambio mejora la experiencia de usuario al hacer el comportamiento del script más transparente directamente desde la terminal.