### PR TITLE
Fix: Hace temporal la bandera de 'unminimize' para idempotencia

### DIFF
--- a/setup_dev_tools.sh
+++ b/setup_dev_tools.sh
@@ -21,14 +21,15 @@ echo "Preparando el sistema base..."
 mkdir -p "$HOME/.cloudshell"
 touch "$HOME/.cloudshell/no-apt-get-warning"
 
-# Restaura el sistema a su estado completo si no se ha hecho antes
-if [ ! -f "$HOME/.unminimize_complete" ]; then
-    echo "Restaurando paquetes y documentación del sistema (operación única)..."
+# Restaura el sistema a su estado completo si no se ha hecho en esta sesión
+UNMINIMIZE_FLAG="/tmp/.unminimize_complete.$(whoami)"
+if [ ! -f "$UNMINIMIZE_FLAG" ]; then
+    echo "Restaurando paquetes y documentación del sistema (operación única para esta sesión)..."
     DEBIAN_FRONTEND=noninteractive sudo unminimize -f
     echo "Sistema restaurado."
-    touch "$HOME/.unminimize_complete"
+    touch "$UNMINIMIZE_FLAG"
 else
-    echo "El sistema ya está completo. Omitiendo."
+    echo "El sistema ya fue restaurado en esta sesión. Omitiendo."
 fi
 
 # --- Parte 1: Configuración de Repositorios Externos ---


### PR DESCRIPTION
Descripción:

  Este Pull Request soluciona un problema de idempotencia en el script
  setup_dev_tools.sh que afectaba a entornos efímeros como Google Cloud
  Shell.

  El Problema:

  El script creaba una bandera de control permanente
  (~/.unminimize_complete) después de ejecutar el comando unminimize por
   primera vez. Dado que el directorio $HOME persiste entre sesiones en
  Cloud Shell, si la primera ejecución de unminimize fallaba o era
  incompleta, el script nunca intentaba volver a ejecutarla en sesiones
  futuras, dejando el sistema en un estado inconsistente.

  La Solución:

  Se ha modificado la lógica para que la bandera de control de
  unminimize se cree y verifique en el directorio temporal /tmp (ej.
  /tmp/.unminimize_complete.hcano_personal).

  Este cambio homologa su comportamiento con el de la bandera principal
  del script (entorno-uno-instalado), asegurando que ambas se eliminen
  cuando la máquina virtual se recicla.

  Resultado:

  Con esta corrección, el proceso de restauración del sistema se
  ejecutará de forma fiable en cada nueva sesión de una máquina virtual,
   garantizando que el entorno de desarrollo siempre se encuentre en el
  estado completo y funcional deseado.